### PR TITLE
Fixes Header activeClass glitch

### DIFF
--- a/client/src/Components/Header/Header.css
+++ b/client/src/Components/Header/Header.css
@@ -25,10 +25,15 @@ header {
 .header a {
   color: white;
   text-decoration: none;
+  outline: none;
 }
 
 .header a:hover {
-  text-decoration: underline;
+  border-bottom: 2px solid rgb(0, 255, 200);
+}
+
+.header a.is-active {
+  border-bottom: 2px solid white;
 }
 
 .header__right a {

--- a/client/src/Components/Header/Header.jsx
+++ b/client/src/Components/Header/Header.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { NavLink } from 'react-router-dom';
+import { NavLink, withRouter } from 'react-router-dom';
 
 import './Header.css';
 
@@ -87,4 +87,4 @@ Header.propTypes = {
   getUser: PropTypes.func,
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(Header);
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(Header));

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -15,8 +15,3 @@ body {
   flex-direction: column;
   height: 100vh;
 }
-
-/* router NavLink active class */
-.is-active {
-  border-bottom: 2px solid white;
-}


### PR DESCRIPTION
Quick fix.

Adding `connect(mapStateToProps, mapDispatchToProps)(Header)` broke react router's `activeClassName` feature. The `is-active` CSS class was not being applied to selected nav links.

Wrapping the `connect()` function in `withRouter()` fixes this.