### PR TITLE
Client - adds Privacy component, styles and route

### DIFF
--- a/client/src/Components/Footer/Footer.css
+++ b/client/src/Components/Footer/Footer.css
@@ -1,7 +1,7 @@
 footer {
   background-color: #333333;
   color: white;
-  height: 80px;
+  min-height: 60px;
 }
 
 .footer {

--- a/client/src/Components/Header/Header.css
+++ b/client/src/Components/Header/Header.css
@@ -4,7 +4,7 @@ header {
   top: 0;
   left: 0;
   width: 100%;
-  height: 80px;
+  min-height: 60px;
 }
 
 .header {

--- a/client/src/Components/Privacy/Privacy.css
+++ b/client/src/Components/Privacy/Privacy.css
@@ -1,0 +1,17 @@
+.privacy {
+  flex: 1;
+  padding: 1em 60px;
+  max-width: 1000px;
+  margin: auto;
+}
+
+.privacy__content {
+  padding: 1em;
+  background-color: #f2f2f2;
+  border: 1px solid #4f4f4f;
+}
+
+.privacy__heading {
+  color: #4f4f4f;
+}
+

--- a/client/src/Components/Privacy/Privacy.jsx
+++ b/client/src/Components/Privacy/Privacy.jsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import './Privacy.css';
+
+const Privacy = () => (
+  <div className="privacy">
+    <div className="privacy__content">
+      <h1 className="privacy__heading">Privacy Policy</h1>
+      <p className="privacy__text">
+        Chingu Bears Team 5 built this Puzzle-Resembling-Tetris app as an Open
+        Source app. This SERVICE is provided by Chingu Bears Team 5 at no cost
+        and is intended for use as is.
+      </p>
+      <p className="privacy__text">
+        This page is intended to inform website visitors and users of our
+        services of our policies regarding the collection, use, and disclosure
+        of Personal Information.
+      </p>
+      <p className="privacy__text">
+        If you choose to use this Service, you agree to the collection and use
+        of information in relation to this policy. The Personal Information that
+        we collect is used for providing and improving this Service. We will
+        not use or share your information with anyone except as described in
+        this Privacy Policy.
+      </p>
+      <h3 className="privacy__heading">Information Collection and Use</h3>
+      <p className="privacy__text">
+        For a better user experience and to improve the Service, we may require
+        you to provide us with certain personally identifiable information,
+        including but not limited to your Google ID, Gmail address, and the
+        name you registered with Google. This information may be collected and
+        retained for the purposes of account creation and authentication.
+      </p>
+      <p className="privacy__text">
+        The app does use third party services (Google) that may collect
+        information used to identify you.
+      </p>
+      <h3 className="privacy__heading">Log Data</h3>
+      <p className="privacy__text">
+        Whenever you use our Service, in the case of an application error we
+        may collect Log Data related to the error. Log Data may include
+        information such as your device Internet Protocol (“IP”) address, device
+        name, operating system version, the configuration of the app when
+        utilizing the Service, the time and date of your use of the Service, and
+        other statistics.
+      </p>
+      <h3 className="privacy__heading">Cookies</h3>
+      <p className="privacy__text">
+        Cookies are files with a small amount of data that are commonly used as
+        anonymous unique identifiers. These are sent to your browser from the
+        websites that you visit and are stored on your device&apos;s internal memory.
+      </p>
+      <p className="privacy__text">
+        This Service uses cookies as part of the authentication mechanism.
+        Additionally, third-party code and libraries may also use cookies to
+        collect information and improve their services. You have the option to
+        either accept or refuse these cookies and know when a cookie is being
+        sent to your device. If you choose to refuse our cookies, you may not be
+        able to use some portions of this Service.
+      </p>
+      <h3 className="privacy__heading">Service Providers</h3>
+      <p className="privacy__text">
+        We may employ third-party companies and individuals due to the following
+        reasons:
+      </p>
+      <ul>
+        <li>To facilitate our Service;</li>
+        <li>To provide the Service on our behalf;</li>
+        <li>To perform Service-related services; or</li>
+        <li>To assist us in analyzing how our Service is used.</li>
+      </ul>
+      <p className="privacy__text">
+        Users of our Service are hereby informed that these third parties may
+        have access to your Personal Information. The reason is to perform the
+        tasks assigned to them on our behalf. However, they are obligated not to
+        disclose or use the information for any other purpose.
+      </p>
+      <h3 className="privacy__heading">Security</h3>
+      <p className="privacy__text">
+        We value your trust and strive to protect your Personal Information
+        using commercially-acceptable means and best-practices. Users of the
+        Service are advised that no method of transmission over the internet,
+        or method of electronic storage is 100% secure and reliable, and that
+        we cannot guarantee its absolute security.
+      </p>
+      <h3 className="privacy__heading">Links to Other Sites</h3>
+      <p className="privacy__text">
+        This Service may contain links to other sites. If you click on a
+        third-party link, you will be directed to that site. Note that these
+        external sites are not operated by us. Therefore, we strongly advise you
+        to review the Privacy Policy of those websites. We have no control over
+        and assume no responsibility for the content, privacy policies, or
+        practices of any third-party sites or services.
+      </p>
+      <h3 className="privacy__heading">Children&apos;s Privacy</h3>
+      <p className="privacy__text">
+        This Services does not address anyone under the age of 13. We do not
+        knowingly collect personally identifiable information from children
+        under 13. Should we discover that a child under 13 has provided us with
+        personal information, we will immediately delete it from our servers.
+        If you are a parent or guardian and you are aware that your child has
+        provided us with personal information, please contact us so that we can
+        take appropriate action.
+      </p>
+      <h3 className="privacy__heading">Changes to This Privacy Policy</h3>
+      <p className="privacy__text">
+        We may update this Privacy Policy periodically. You are advised to
+        review this page for changes. We will notify you of any changes by
+        posting the new Privacy Policy on this page. These changes are
+        effective immediately upon publication herein.
+      </p>
+      <h3 className="privacy__heading">Contact Us</h3>
+      <p className="privacy__text">
+        If you have any questions or suggestions about this Privacy Policy, do
+        not hesitate to contact us.
+      </p>
+    </div>
+  </div>
+);
+
+export default Privacy;

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -6,7 +6,7 @@ html, body {
 }
 
 body {
-  background: url('./assets/splash.jpg');
+  background: url('./assets/splash.jpg') no-repeat center center fixed;
   background-size: cover;
 }
 

--- a/client/src/routers/AppRouter.jsx
+++ b/client/src/routers/AppRouter.jsx
@@ -9,6 +9,7 @@ import Landing from '../Components/Landing/Landing';
 import Leaderboard from '../Components/Leaderboard/Leaderboard';
 import Login from '../Components/Login/Login';
 import Register from '../Components/Register/Register';
+import Privacy from '../Components/Privacy/Privacy';
 
 const AppRouter = () => (
   <BrowserRouter>
@@ -19,6 +20,7 @@ const AppRouter = () => (
         <Route path="/leaderboard" component={Leaderboard} />
         <Route path="/login" component={Login} />
         <Route path="/register" component={Register} />
+        <Route path="/privacy" component={Privacy} />
         <Route component={FourOhFour} />
       </Switch>
       <Footer />


### PR DESCRIPTION
Main changes
* Adds Privacy component with slightly-customized boilerplate language
* Adds basic Privacy component CSS

Minor fixes
* Background image would repeat if page content was very long (like the Privacy boilerplate). Fix = set background image to fixed, no-repeat.
* Header and Footer `height` would change if page content was very long. Fix = change `height` to `min-height`.
* Reduced Header and Footer min-height to 60px. 80px looked a bit too large.